### PR TITLE
Added simple save_model function to network class

### DIFF
--- a/tfoptflow/model_base.py
+++ b/tfoptflow/model_base.py
@@ -191,6 +191,11 @@ class ModelBase:
     ###
     # Model mgmt
     ###
+    def save_model(self):
+        """Save model. Override this.
+        """
+        raise NotImplementedError
+
     def build_model(self):
         """Build model. Override this.
         """

--- a/tfoptflow/model_pwcnet.py
+++ b/tfoptflow/model_pwcnet.py
@@ -236,6 +236,23 @@ class ModelPWCNet(ModelBase):
     ###
     # Model mgmt
     ###
+    def save_model(self, export_dir):
+        """Save model
+        Used for saving the model in the SavedModel format. Allows for simple interfacing with ONNX conversion
+        """
+        if self.opts['verbose']:
+            print("Saving model...")
+        assert(self.num_gpus <= 1)
+
+        # Save the backbone neural nets
+        with self.graph.as_default():
+            flow_pred_tnsr = tf.identity(self.flow_pred_tnsr, 'flow_pred_tnsr')
+            tf.saved_model.simple_save(self.sess, export_dir, inputs={'x_tnsr': self.x_tnsr},
+                                   outputs={'flow_pred_tnsr': flow_pred_tnsr})
+
+        if self.opts['verbose']:
+            print("... model saved.")
+
     def build_model(self):
         """Build model
         Called by the base class when building the TF graph to setup the list of output tensors


### PR DESCRIPTION
SavedModel is the preferred format for ONNX-to-TensorFlow conversion. This short and simple save option allows saving in this format. Deployment in TensorRT environment etc. is then also simpler.